### PR TITLE
fix: ステージングCDにLaprasデータ取得ステップを追加

### DIFF
--- a/.github/workflows/cd-staging.yml
+++ b/.github/workflows/cd-staging.yml
@@ -28,6 +28,9 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Fetch Lapras data
+        run: node fetch-lapras.mjs
+
       - name: Build (staging base path)
         run: npm run build
         env:


### PR DESCRIPTION
cd-staging.ymlにfetch-lapras.mjsの実行が抜けていたため、
ステージング環境でLapras APIデータが取得できなかった。